### PR TITLE
action.yaml: update to newer Github actions versions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,13 +20,13 @@ runs:
   using: "composite"
   steps:
   - name: Check out the code
-    uses: actions/checkout@v2
+    uses: actions/checkout@v3
     with:
       # Get all branches and history
       fetch-depth: 0
 
   - name: Setup Python
-    uses: actions/setup-python@v2
+    uses: actions/setup-python@v4
     with:
       python-version: '3.x'
 


### PR DESCRIPTION
Per https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/, update to use newer versions of github actions so that we stop getting warnings about outdated Node.js versions.